### PR TITLE
elm-format: GHC 8 compatibility

### DIFF
--- a/Formula/elm-format.rb
+++ b/Formula/elm-format.rb
@@ -19,6 +19,11 @@ class ElmFormat < Formula
   def install
     (buildpath/"elm-format").install Dir["*"]
 
+    # GHC 8 compat
+    # Fixes: "cabal: Could not resolve dependencies"
+    # Reported 26 May 2016: https://github.com/avh4/elm-format/issues/188
+    (buildpath/"cabal.config").write("allow-newer aeson,base,transformers\n")
+
     cabal_sandbox do
       cabal_sandbox_add_source "elm-format"
       cabal_install "--only-dependencies", "elm-format"


### PR DESCRIPTION
Without adding "allow-newer" for aeson, base, and transformers, I get
the build failure:

```
Resolving dependencies...
cabal: Could not resolve dependencies:
trying: elm-format-0.3.0 (user goal)
trying: transformers-0.5.2.0/installed-0.5... (dependency of
regex-applicative-0.3.3)
next goal: optparse-applicative (dependency of elm-format-0.3.0)
rejecting: optparse-applicative-0.12.1.0, optparse-applicative-0.12.0.0
(conflict: elm-format => optparse-applicative>=0.11 && <0.12)

etc. etc.
```

Can be removed as soon as elm-format and the dependencies setting unecessary
restrictions on these versions catch up, or as soon as elm-format itself has a
similar built-in workaround.
